### PR TITLE
Add redhatdistortion-maven jenkins slave to config

### DIFF
--- a/configuration/config.xml
+++ b/configuration/config.xml
@@ -54,6 +54,17 @@
           <label>agent</label>
           <volumes/>
         </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+        <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+          <name>redhatdistortion-maven</name>
+          <image>docker.io/redhatdistortion/maven-jenkins-slave</image>
+          <privileged>false</privileged>
+          <command></command>
+          <args></args>
+          <remoteFs>/opt/app-root/jenkins</remoteFs>
+          <instanceCap>2147483647</instanceCap>
+          <label>redhatdistortion-maven</label>
+          <volumes/>
+        </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
       </templates>
       <serverUrl>https://kubernetes.default</serverUrl>
       <skipTlsVerify>false</skipTlsVerify>


### PR DESCRIPTION
I have exported the config from my instance where it worked, but I am not sure how to test it with the whole plugin. Although it should be most probably fine since I took it from already running instance.

Please review.

cc: @bparees @ALRubinger