### PR TITLE
[WIP] Tune GC setting to fix Jenkins slow boot and hangs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ def repo = 'openshift-jenkins-s2i-config'
 def org = 'fabric8io'
 def project = org + '/' + repo
 def flow = new io.fabric8.Fabric8Commands()
-def baseImageVerion = "v0072490"
+def baseImageVerion = "PR-34-1"
 def deploySnapshot = false
 def pipeline
 def snapshotImageName


### PR DESCRIPTION
Jenkins works really slow during first boot and unideling phase. It turns out that JVM garbage Collector occupies most of CPU during startup, hence it hangs the Jenkins.
This patch uses a [new base image](https://github.com/fabric8-jenkins/jenkins-openshift-base/pull/34) which has tweaked a couple of JVM parameters.
